### PR TITLE
fix/current version

### DIFF
--- a/current_version.json
+++ b/current_version.json
@@ -2,11 +2,11 @@
     "tag_name": "v1.0.7",
     "assets": [
 		{
-			"browser_download_url": "https://github.com/ABaumher/galaxy-integration-steam/releases/download/v1.0.7/windows.zip",
+			"browser_download_url": "https://github.com/GOG-Nebula/galaxy-integration-steam/releases/download/v1.0.7/windows.zip",
 			"name": "windows.zip"
 		},
 		{
-			"browser_download_url": "https://github.com/ABaumher/galaxy-integration-steam/releases/download/v1.0.7/mac.zip",
+			"browser_download_url": "https://github.com/GOG-Nebula/galaxy-integration-steam/releases/download/v1.0.7/mac.zip",
 			"name": "mac.zip"
 		}
     ]


### PR DESCRIPTION
it doesn't really matter that the zips aren't in the releases yet imo

we should probably think about the security implications of being able to edit the release after the fact. the only real solution is to find a file hosting provider provides a url that depends on the contents of the file (url changes if file changes). we could do this by just hosting the files in a repo. but tbh if the members of the repo are trusted it should be alr