### PR TITLE
Bugfix: Allow Credentials to Recover from Expired tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ output/
 /protoc
 *.zip
 *.gz
+/.env

--- a/current_version.json
+++ b/current_version.json
@@ -1,12 +1,12 @@
 {
-    "tag_name": "v1.0.7",
+    "tag_name": "v1.0.8",
     "assets": [
 		{
-			"browser_download_url": "https://github.com/GOG-Nebula/galaxy-integration-steam/releases/download/v1.0.7/windows.zip",
+			"browser_download_url": "https://github.com/GOG-Nebula/galaxy-integration-steam/releases/download/v1.0.8/windows.zip",
 			"name": "windows.zip"
 		},
 		{
-			"browser_download_url": "https://github.com/GOG-Nebula/galaxy-integration-steam/releases/download/v1.0.7/mac.zip",
+			"browser_download_url": "https://github.com/GOG-Nebula/galaxy-integration-steam/releases/download/v1.0.8/mac.zip",
 			"name": "mac.zip"
 		}
     ]

--- a/galaxy-integration-steam.pyproj
+++ b/galaxy-integration-steam.pyproj
@@ -13,6 +13,7 @@
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <InterpreterId>MSBuild|env1|$(MSBuildProjectFullPath)</InterpreterId>
     <TestFramework>Pytest</TestFramework>
+    <SuppressConfigureTestFrameworkPrompt>true</SuppressConfigureTestFrameworkPrompt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Galaxy Steam plugin Version 2",
 	"platform": "steam",
 	"guid": "ca27391f-2675-49b1-92c0-896d43afa4f8",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "Galaxy plugin for Steam. Updated with new authentication logic",
 	"author": "ABaumher, don-de-marco, et al.",
 	"email": "baumhera912@gmail.com",

--- a/src/steam_network/protocol_client.py
+++ b/src/steam_network/protocol_client.py
@@ -285,6 +285,8 @@ class ProtocolClient:
             self._auth_lost_handler = auth_lost_handler
         elif result == EResult.AccessDenied:
             return UserActionRequired.InvalidAuthData
+        elif result == EResult.Expired
+            return UserActionRequired.InvalidAuthData
         else:
             logger.warning(f"authenticate_token failed with code: {result}")
             raise translate_error(result)

--- a/src/steam_network/protocol_client.py
+++ b/src/steam_network/protocol_client.py
@@ -285,7 +285,7 @@ class ProtocolClient:
             self._auth_lost_handler = auth_lost_handler
         elif result == EResult.AccessDenied:
             return UserActionRequired.InvalidAuthData
-        elif result == EResult.Expired
+        elif result == EResult.Expired:
             return UserActionRequired.InvalidAuthData
         else:
             logger.warning(f"authenticate_token failed with code: {result}")

--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,10 @@
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 __changelog__ = {
     "unreleased": '''
     ''',
+     "1.0.8": """
+    - Fixes issue when credential token expires. 
+    """,
     "1.0.7": """
     - Fixes issues when SteamGuard is disabled. Made it so 2FA codes would ignore leading or trailing whitespace.
     - Code cleanup


### PR DESCRIPTION
After roughly 7 months, the refresh tokens given for credentials expire. This was assumed to be addressed, but we could not test to confirm it (we tried expiring the token manually, but this brought different results). This would result in an unknown error, which would cause the plugin to crash gracefully and just say "offline, retry". Accepting this error will allow it to prompt user for login and get a new token.

see: https://github.com/ABaumher/galaxy-integration-steam/issues/55